### PR TITLE
Adding an override of graceful-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "datetime": "0.0.3",
     "jsonfile": "^4.0.0",
     "node-datetime": "^2.0.0"
+  },
+  "overrides": {
+    "graceful-fs": "^4.2.9"
   }
 }


### PR DESCRIPTION
This fixes a compatibility issue in node versions >= 8.3.0 which should be standard by now. For reference see: https://stackoverflow.com/questions/55921442/how-to-fix-referenceerror-primordials-is-not-defined-in-node-js