### PR TITLE
Bug 29844 follow-up (as_list)

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/KitchenSink.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/KitchenSink.pm
@@ -405,8 +405,8 @@ sub report_step1 {
 
     my $template = $self->get_template({ file => 'report-step1.tt' });
 
-    my @libraries = Koha::Libraries->search;
-    my @categories = Koha::Patron::Categories->search({}, {order_by => ['description']});
+    my @libraries = Koha::Libraries->search->as_list;
+    my @categories = Koha::Patron::Categories->search({}, {order_by => ['description']})->as_list;
     $template->param(
         libraries => \@libraries,
         categories => \@categories,


### PR DESCRIPTION
Bug 29844 removed uses of wantarray in Koha::Objects. So, to get a lists that can be iterated in the report-step1.tt template a call to as_list is needed.  Otherwise the script fails with error messages:
The method Koha::Libraries->branchcode is not covered by tests 
and:
The method Koha::Patron::Categories->categorycode is not covered by tests