### PR TITLE
Bug 34478 follow-up: Add missing CSRF token to POST forms

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/KitchenSink.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/KitchenSink.pm
@@ -477,7 +477,7 @@ sub report_step2 {
     $template->param(
         date_ran     => dt_from_string(),
         results_loop => \@results,
-        branch       => GetBranchName($branch),
+        branch       => Koha::Libraries->find($branch)->branchname,
     );
 
     unless ( $category_code eq '%' ) {

--- a/Koha/Plugin/Com/ByWaterSolutions/KitchenSink/opac_online_payment_begin.tt
+++ b/Koha/Plugin/Com/ByWaterSolutions/KitchenSink/opac_online_payment_begin.tt
@@ -72,6 +72,7 @@
 
 
                     <form method="post" action="[% OPACBaseURL %]/cgi-bin/koha/opac-account-pay-return.pl">
+                        [% INCLUDE 'csrf-token.inc' %]
                         <input type="hidden" name="BillingAddress" value="[% borrower.address %]" />
                         <input type="hidden" name="BillingName" value="[% borrower.firstname %] [% borrower.surname %]" />
                         <input type="hidden" name="BillingCountry" value="US" />

--- a/Koha/Plugin/Com/ByWaterSolutions/KitchenSink/tool-step1.tt
+++ b/Koha/Plugin/Com/ByWaterSolutions/KitchenSink/tool-step1.tt
@@ -13,6 +13,7 @@
 
     <!-- Notice our form here has no 'action', this is good, it means that our forms will always get passed back to 'plugins/run.pl'. You could hard code it instead if you prefer -->
     <form method="post">
+        [% INCLUDE 'csrf-token.inc' %]
         <input type="hidden" name="class" value="[% CLASS %]"/>
         <input type="hidden" name="method" value="[% METHOD %]"/>
 
@@ -24,6 +25,7 @@
     <br/>
 
     <form method="post">
+        [% INCLUDE 'csrf-token.inc' %]
         <input type="hidden" name="class" value="[% CLASS %]"/>
         <input type="hidden" name="method" value="[% METHOD %]"/>
 


### PR DESCRIPTION
I was able to test Koha/Plugin/Com/ByWaterSolutions/KitchenSink/tool-step1.tt. The correction in Koha/Plugin/Com/ByWaterSolutions/KitchenSink/opac_online_payment_begin.tt is analogous. 