### PR TITLE
Bug 15758 follow-up: Koha::Libraries - Ultimate duel for C4::Branch

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/KitchenSink.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/KitchenSink.pm
@@ -477,7 +477,7 @@ sub report_step2 {
     $template->param(
         date_ran     => dt_from_string(),
         results_loop => \@results,
-        branch       => GetBranchName($branch),
+        branch       => Koha::Libraries->find($branch)->branchname,
     );
 
     unless ( $category_code eq '%' ) {


### PR DESCRIPTION
C4::Branch::GetBranchName does not exist any longer. Koha::Library->branchname should be useed instead.