### PR TITLE
Fix Spock hand icon button

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/KitchenSink.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/KitchenSink.pm
@@ -317,8 +317,8 @@ sub intranet_catalog_biblio_enhancements_toolbar_button {
     my ( $self ) = @_;
 
     return q|
-        <a class="btn btn-default btn-sm" onclick="alert('Peace and long life');">
-          <i class="fa fa-hand-spock-o" aria-hidden="true"></i>
+        <a class="btn btn-default" role="button" tabindex="0" onclick="alert('Peace and long life');">
+          <i class="fa fa-hand-spock" aria-hidden="true"></i>
           Live long and prosper
         </a>
     |;


### PR DESCRIPTION
This patch updates the font awesome class to fix the display of the Spock hand icon in the cataloging toolbar example. It also adds the button role and tabindex for better accessibility.

To test:
1. Go to the details page of a bibliographic record
2. Notice the live long and prosper button is missing the Spock hand icon and is not tabbable
3. Apply patch and restart_all
4. Confirm the Spock hand displays correctly and the button is now tabbable

Peace and long life.